### PR TITLE
Need to remove extra work field, it is not used any more for Ropecon

### DIFF
--- a/events/ropecon2018/forms.py
+++ b/events/ropecon2018/forms.py
@@ -22,7 +22,6 @@ class SignupExtraForm(forms.ModelForm):
         self.helper.form_tag = False
         self.helper.layout = Layout(
             'shift_type',
-            'extra_work',
 
             Fieldset('Työtodistus',
                 'want_certificate',
@@ -42,7 +41,6 @@ class SignupExtraForm(forms.ModelForm):
         model = SignupExtra
         fields = (
             'shift_type',
-            'extra_work',
             'want_certificate',
             'certificate_delivery_address',
             'special_diet',
@@ -128,7 +126,6 @@ class OrganizerSignupExtraForm(forms.ModelForm, AlternativeFormMixin):
     def get_excluded_field_defaults(self):
         return dict(
             shift_type='kaikkikay',
-            extra_work='ei',
             want_certificate=False,
             certificate_delivery_address='',
             prior_experience='',

--- a/events/ropecon2018/models.py
+++ b/events/ropecon2018/models.py
@@ -10,11 +10,6 @@ TOTAL_WORK_CHOICES = [
     ('yli12h', 'Työn Sankari! Yli 12 tuntia!'),
 ]
 
-EXTRA_WORK_CHOICES = [
-    ('miel', 'Otan mielelläni varatyövoimavuoron'),
-    ('ei', 'En halua varatyövuoroa'),
-]
-
 SHIFT_TYPE_CHOICES = [
     ('yksipitka', 'Yksi pitkä vuoro'),
     ('montalyhytta', 'Monta lyhyempää vuoroa'),
@@ -50,12 +45,6 @@ class SignupExtra(ObsoleteSignupExtraBaseV1):
         verbose_name='Toivottu kokonaistyömäärä',
         help_text='Kuinka paljon haluat tehdä töitä yhteensä tapahtuman aikana? Useimmissa tehtävistä minimi on kahdeksan tuntia, mutta joissain tehtävissä se voi olla myös vähemmän (esim. majoitusvalvonta 6 h).',
         choices=TOTAL_WORK_CHOICES,
-    )
-
-    extra_work = models.CharField(max_length=5,
-        verbose_name='Haluatko päivystää varatyövoimana?',
-        help_text='Varatyövoiman päivystysvuoro on 4h, jonka aikana sinun tulee olla tavoitettavissa puhelimella Messukeskuksessa. Voit joutua mihin tahansa työpisteeseen paikkaamaan',
-        choices=EXTRA_WORK_CHOICES,
     )
 
     want_certificate = models.BooleanField(


### PR DESCRIPTION
Would be nice to have this included soonish, but our labour admin can live with the current form version until this is applied.