### PR TITLE
Ropecon specific programme listing as JSON

### DIFF
--- a/programme/models/programme.py
+++ b/programme/models/programme.py
@@ -845,6 +845,7 @@ class Programme(models.Model, CsvExportMixin):
                 children_friendly=self.is_children_friendly if self.category.slug == 'roolipeli' else None,
                 age_restricted=self.is_age_restricted if self.category.slug == 'roolipeli' else None,
                 beginner_friendly=self.is_beginner_friendly if self.category.slug == 'roolipeli' else None,
+                intended_for_experienced_participants=self.is_intended_for_experienced_participants if self.category.slug == 'roolipeli' else None,
                 min_players=self.min_players if self.category.slug == 'roolipeli' else None,
                 max_players=self.max_players if self.category.slug == 'roolipeli' else None,
                 identifier='p{id}'.format(id=self.id),

--- a/programme/models/programme.py
+++ b/programme/models/programme.py
@@ -844,7 +844,9 @@ class Programme(models.Model, CsvExportMixin):
                 'is_children_friendly',
                 'is_age_restricted',
                 'is_beginner_friendly',
-
+                              
+                min_players=self.min_players if self.category.slug == 'roolipeli' else None,
+                max_players=self.max_players if self.category.slug == 'roolipeli' else None,
                 identifier='p{id}'.format(id=self.id),
                 tags=list(self.tags.values_list('slug', flat=True)),
                 genres=self.ropecon_genres,

--- a/programme/models/programme.py
+++ b/programme/models/programme.py
@@ -839,12 +839,12 @@ class Programme(models.Model, CsvExportMixin):
                 'end_time',
                 'language',
                 'rpg_system',
-                'ropecon2018_is_no_language',
-                'is_english_ok',
-                'is_children_friendly',
-                'is_age_restricted',
-                'is_beginner_friendly',
-                              
+                                  
+                no_language=self.ropecon2018_is_no_language if self.category.slug == 'roolipeli' else None,
+                english_ok=self.is_english_ok if self.category.slug == 'roolipeli' else None,
+                children_friendly=self.is_children_friendly if self.category.slug == 'roolipeli' else None,
+                age_restricted=self.is_age_restricted if self.category.slug == 'roolipeli' else None,
+                beginner_friendly=self.is_beginner_friendly if self.category.slug == 'roolipeli' else None,
                 min_players=self.min_players if self.category.slug == 'roolipeli' else None,
                 max_players=self.max_players if self.category.slug == 'roolipeli' else None,
                 identifier='p{id}'.format(id=self.id),

--- a/programme/models/programme.py
+++ b/programme/models/programme.py
@@ -827,9 +827,49 @@ class Programme(models.Model, CsvExportMixin):
                 presenter=self.formatted_hosts,
                 tags=list(self.tags.values_list('slug', flat=True)),
             )
+        elif format == 'ropecon':
+            return pick_attrs(self,
+                'title',
+                'description',
+                'category_title',
+                'formatted_hosts',
+                'room_name',
+                'length',
+                'start_time',
+                'end_time',
+                'language',
+                'rpg_system',
+                'ropecon2018_is_no_language',
+                'is_english_ok',
+                'is_children_friendly',
+                'is_age_restricted',
+                'is_beginner_friendly',
+
+                identifier='p{id}'.format(id=self.id),
+                tags=list(self.tags.values_list('slug', flat=True)),
+                genres=self.ropecon_genres,
+                styles=self.ropecon_styles,
+                              
+            )
         else:
             raise NotImplementedError(format)
 
+    @property
+    def ropecon_genres(self):
+        genres = []
+        for genre in ['fantasy','scifi','historical','modern','war','horror','exploration','mystery','drama','humor']:
+            if getattr(self, 'ropecon2018_genre_' + genre):
+                genres.append(genre)
+        return genres
+    
+    @property
+    def ropecon_styles(self):
+        styles = []
+        for style in ['serious','light','rules_heavy','rules_light','story_driven','character_driven','combat_driven']:
+            if getattr(self, 'ropecon2018_style_' + style):
+                styles.append(style)
+        return styles
+    
     @property
     def state_css(self):
         return STATE_CSS[self.state]

--- a/programme/urls.py
+++ b/programme/urls.py
@@ -133,10 +133,10 @@ urlpatterns = [
     ),
 
     url(
-        r'^events/(?P<event_slug>[a-z0-9-]+)/programme/ropecon\.json$',
+        r'^api/v1/events/(?P<event_slug>[a-z0-9-]+)/programme/ropecon$',
         programme_json_view,
         dict(format='ropecon'),
-        name='programme_moe_view',
+        name='programme_rcon_view',
     ),
 
     url(

--- a/programme/urls.py
+++ b/programme/urls.py
@@ -133,6 +133,13 @@ urlpatterns = [
     ),
 
     url(
+        r'^events/(?P<event_slug>[a-z0-9-]+)/programme/ropecon\.json$',
+        programme_json_view,
+        dict(format='ropecon'),
+        name='programme_moe_view',
+    ),
+
+    url(
         r'^events/(?P<event_slug>[a-z0-9-]+)/programme/invitation/(?P<code>[a-f0-9]+)/?$',
         programme_accept_invitation_view,
         name='programme_accept_invitation_view',


### PR DESCRIPTION
Ropecon requires additional data fields in the JSON programme listing for Konopas. Genres and styles is a hack from our old DB and might be better in some other way. Tested to work on my laptop, and the format is acceptable for Konopas developers (almost anything is).