### PR TITLE
make order number visible during ordering

### DIFF
--- a/tickets/models.py
+++ b/tickets/models.py
@@ -841,7 +841,8 @@ class Order(models.Model):
 
     @property
     def checkout_message(self):
-        return ", ".join(i.description for i in self.order_product_set.filter(count__gte=1))
+        products = ", ".join(i.description for i in self.order_product_set.filter(count__gte=1))
+        return f"{self.formatted_order_number}: {products}"
 
     def checkout_mac(self, request):
         return compute_payment_request_mac(request, self)

--- a/tickets/templates/tickets_confirm_phase.pug
+++ b/tickets/templates/tickets_confirm_phase.pug
@@ -1,6 +1,8 @@
 extends tickets_phase_base.pug
 - load i18n
 block body_text
+
+  .pull-right.text-muted {{ order.formatted_order_number }}
   h2 {% trans "Confirm order" %}
   p {% blocktrans %}Please check your delivery information, especially the e-mail address, and the amounts of products being ordered. By selecting <em>Proceed to payment</em> you will navigate to a payment page on which you will select the payment method.{% endblocktrans %}
 

--- a/tickets/templates/tickets_thanks_phase.pug
+++ b/tickets/templates/tickets_thanks_phase.pug
@@ -1,6 +1,7 @@
 extends tickets_phase_base.pug
 - load i18n
 block body_text
+  .pull-right.text-muted {{ order.formatted_order_number }}
   h2 {% trans "Thank you for your order!" %}
   p {% trans "Your order is now complete. Welcome to the event!" %}
 block form_content


### PR DESCRIPTION
Make order number visible during ordering by adding order number to tickets_order_fragment.pug
Since the order number is probably the least important part normally, it's added to the bottom of the page. No highlight formatting is used for the same reason.

Exposing the order number here allows referencing the order number when registering payments via other means (e.g. credit/debit card with PoS reader over the counter) without requiring ticket sales admin rights.