### PR TITLE
chore(ropecon2025): Add dev.kompassi to staging allowed CSP

### DIFF
--- a/backend/kubernetes/staging.vars.yaml
+++ b/backend/kubernetes/staging.vars.yaml
@@ -24,6 +24,7 @@ kompassi_admins:
   - Santtu Pajukanta <santtu@pajukanta.fi>
 
 kompassi_csp_allowed_login_redirects:
+  - https://dev.kompassi.eu
   - dev.ropekonsti.fi
   - localhost:3000
   - localhost:5000


### PR DESCRIPTION
Add `https://dev.kompassi` to staging allowed CSP. Trying to debug why `localhost:8000` OAuth flow doesn't work on Chrome but works on Firefox.