### PR TITLE
Update pieni-sali.csv

### DIFF
--- a/kompassi/program_v2/integrations/paikkala_data/tampere-talo/pieni-sali.csv
+++ b/kompassi/program_v2/integrations/paikkala_data/tampere-talo/pieni-sali.csv
@@ -39,4 +39,4 @@ Permanto vasen (2. krs),15,327,337
 Permanto oikea (2. krs),16,338,349
 Permanto vasen (2. krs),16,350,360
 Permanto oikea (2. krs),17,361,370
-Permanto vasen (2. krs),17,374,382
+Permanto vasen (2. krs),17,374,377


### PR DESCRIPTION
Pienen salin paikkalippupaikkoja muutettiin poistamalla rivin 17 paikat 378-382 kuulokojeen käyttöalueelta esteettömyyskäyttöön.