### PR TITLE
chore(ropecon2026): Staging CSP: include schema in localhost

### DIFF
--- a/kubernetes/staging.vars.yaml
+++ b/kubernetes/staging.vars.yaml
@@ -25,9 +25,12 @@ kompassi_admins:
 
 kompassi_csp_allowed_login_redirects:
   - dev.ropekonsti.fi
-  - localhost:3000
-  - localhost:5000
-  - localhost:8000
+  - http://localhost:3000
+  - https://localhost:3000
+  - http://localhost:5000
+  - https://localhost:5000
+  - http://localhost:8000
+  - https://localhost:8000
   - ropekonsti.fi
   - wp.ropecon.fi
   - dev.larpit.fi


### PR DESCRIPTION
Add explicit `http`/`https` schema to dev Kompassi allowed CSP localhost addresses. Trying to debug why `http://localhost:8000` OAuth flow doesn't work on Chrome but works on Firefox.

Localhost `http` login callback fails because Chrome is more strict than Firefox and schema must match.