### PR TITLE
fix(core): move RequestLocalCache dicts to __init__ to prevent cross-request cache bleed

### DIFF
--- a/kompassi/core/middleware.py
+++ b/kompassi/core/middleware.py
@@ -64,15 +64,12 @@ class UniverseCache:
 
 
 class RequestLocalCache:
-    request: HttpRequest
-    _event_cache: dict[str, EventCache] = {}
-    _universe_cache: dict[int, UniverseCache] = {}
-
-    # event id -> UniverseCache
-    _program_universe_cache: dict[int, UniverseCache] = {}
-
     def __init__(self, request: HttpRequest):
         self.request = request
+        self._event_cache: dict[str, EventCache] = {}
+        self._universe_cache: dict[int, UniverseCache] = {}
+        # event id -> UniverseCache
+        self._program_universe_cache: dict[int, UniverseCache] = {}
 
     def for_event(self, event: Event) -> EventCache:
         if event.slug not in self._event_cache:


### PR DESCRIPTION
Class-level mutable dict defaults are shared across all instances, causing
dimension caches to persist across HTTP requests instead of being per-request.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
