### PR TITLE
fix(tickets_v2): validate customer names to prevent Paytrail API errors

### DIFF
--- a/kompassi-v2-frontend/src/components/forms/SchemaFormInput.tsx
+++ b/kompassi-v2-frontend/src/components/forms/SchemaFormInput.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Card from "react-bootstrap/Card";
 import CardBody from "react-bootstrap/CardBody";
 import makeInputId from "./makeInputId";
@@ -55,6 +57,25 @@ function SchemaFormInput({
           readOnly={readOnly}
           id={id}
           name={slug}
+          pattern={field.pattern}
+          maxLength={field.maxLength}
+          title={field.patternDescription}
+          onInvalid={
+            field.patternDescription
+              ? (e) => {
+                  if (e.currentTarget.validity.patternMismatch) {
+                    e.currentTarget.setCustomValidity(
+                      field.patternDescription!,
+                    );
+                  }
+                }
+              : undefined
+          }
+          onChange={
+            field.patternDescription
+              ? (e) => e.currentTarget.setCustomValidity("")
+              : undefined
+          }
         />
       );
     case "MultiLineText":

--- a/kompassi-v2-frontend/src/components/forms/models.ts
+++ b/kompassi-v2-frontend/src/components/forms/models.ts
@@ -91,15 +91,14 @@ export interface StaticText extends BaseField {
 
 export interface SingleLineText extends BaseField {
   type: "SingleLineText";
+  pattern?: string;
+  patternDescription?: string;
+  maxLength?: number;
 }
 
 export interface MultiLineText extends BaseField {
   type: "MultiLineText";
   rows?: number;
-}
-
-export interface SingleLineText extends BaseField {
-  type: "SingleLineText";
 }
 
 export interface NumberField extends BaseField {

--- a/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
+++ b/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
@@ -26,7 +26,7 @@ function getContactFormFields(
   termsAndConditionsUrl?: string,
 ): Field[] {
   // Paytrail documents max 50 chars for names; dots and pipes are known to cause API errors.
-  const namePattern = "[^|.\\x00-\\x1f\\x7f]+";
+  const namePattern = "[^\\|.\\x00-\\x1f\\x7f]+";
   const fields: Field[] = [
     {
       slug: "firstName",

--- a/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
+++ b/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
@@ -26,7 +26,11 @@ function getContactFormFields(
   termsAndConditionsUrl?: string,
 ): Field[] {
   // Paytrail documents max 50 chars for names; dots and pipes are known to cause API errors.
-  const namePattern = "[^\\|.\\x00-\\x1f\\x7f]+";
+  // Block all ASCII punctuation except space, apostrophe and hyphen, plus control chars and DEL.
+  // Hex escapes avoid Chrome v-flag escaping pitfalls. Keep in sync with CUSTOMER_NAME_PATTERN
+  // in tickets_v2/optimized_server/models/customer.py (which adds anchors; HTML pattern is auto-anchored).
+  const namePattern =
+    "[^\\x00-\\x1f\\x21-\\x26\\x28-\\x2c\\x2e\\x2f\\x3a-\\x40\\x5b-\\x60\\x7b-\\x7f]+";
   const fields: Field[] = [
     {
       slug: "firstName",

--- a/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
+++ b/kompassi-v2-frontend/src/components/tickets/ContactForm.tsx
@@ -25,18 +25,26 @@ function getContactFormFields(
   isAdmin: boolean,
   termsAndConditionsUrl?: string,
 ): Field[] {
+  // Paytrail documents max 50 chars for names; dots and pipes are known to cause API errors.
+  const namePattern = "[^|.\\x00-\\x1f\\x7f]+";
   const fields: Field[] = [
     {
       slug: "firstName",
       type: "SingleLineText",
       required: true,
       title: t.attributes.firstName.title,
+      pattern: namePattern,
+      patternDescription: t.attributes.invalidNameMessage,
+      maxLength: 50,
     },
     {
       slug: "lastName",
       type: "SingleLineText",
       required: true,
       title: t.attributes.lastName.title,
+      pattern: namePattern,
+      patternDescription: t.attributes.invalidNameMessage,
+      maxLength: 50,
     },
     {
       slug: "email",

--- a/kompassi-v2-frontend/src/translations/en.tsx
+++ b/kompassi-v2-frontend/src/translations/en.tsx
@@ -658,6 +658,8 @@ const translations = {
         lastName: {
           title: "Last name",
         },
+        invalidNameMessage:
+          "Name must not contain dots (.) or other special characters.",
         displayName: {
           title: "Customer name",
         },

--- a/kompassi-v2-frontend/src/translations/fi.tsx
+++ b/kompassi-v2-frontend/src/translations/fi.tsx
@@ -652,6 +652,8 @@ const translations: Translations = {
         lastName: {
           title: "Sukunimi",
         },
+        invalidNameMessage:
+          "Nimi ei saa sisältää pistettä (.) tai muita erikoismerkkejä.",
         displayName: {
           title: "Asiakkaan nimi",
         },

--- a/kompassi-v2-frontend/src/translations/sv.tsx
+++ b/kompassi-v2-frontend/src/translations/sv.tsx
@@ -640,6 +640,8 @@ const translations: Translations = {
         ),
         firstName: { title: "Förnamn" },
         lastName: { title: "Efternamn" },
+        invalidNameMessage:
+          "Namnet får inte innehålla punkt (.) eller andra specialtecken.",
         displayName: { title: "Kundnamn" },
         email: {
           title: "E-postadress",

--- a/kompassi/tickets_v2/optimized_server/models/customer.py
+++ b/kompassi/tickets_v2/optimized_server/models/customer.py
@@ -2,7 +2,11 @@ import pydantic
 
 # Paytrail documents max 50 chars for firstName/lastName.
 # Dots and pipes are known to cause Paytrail API errors (pipe is documented; dot empirical).
-CUSTOMER_NAME_PATTERN = r"[^|.\x00-\x1f\x7f]+"
+# Block all ASCII punctuation except space, apostrophe and hyphen, plus control chars and DEL.
+# Anchors are required: pydantic pattern is an unanchored search, unlike the HTML pattern attribute.
+# Must be \A...\z (not \Z) for pydantic's Rust regex engine. Keep the character class in sync
+# with namePattern in kompassi-v2-frontend/src/components/tickets/ContactForm.tsx.
+CUSTOMER_NAME_PATTERN = r"\A[^\x00-\x1f\x21-\x26\x28-\x2c\x2e\x2f\x3a-\x40\x5b-\x60\x7b-\x7f]+\z"
 
 
 class Customer(pydantic.BaseModel, frozen=True, populate_by_name=True):

--- a/kompassi/tickets_v2/optimized_server/models/customer.py
+++ b/kompassi/tickets_v2/optimized_server/models/customer.py
@@ -1,5 +1,9 @@
 import pydantic
 
+# Paytrail documents max 50 chars for firstName/lastName.
+# Dots and pipes are known to cause Paytrail API errors (pipe is documented; dot empirical).
+CUSTOMER_NAME_PATTERN = r"[^|.\x00-\x1f\x7f]+"
+
 
 class Customer(pydantic.BaseModel, frozen=True, populate_by_name=True):
     """
@@ -10,12 +14,14 @@ class Customer(pydantic.BaseModel, frozen=True, populate_by_name=True):
     first_name: str = pydantic.Field(
         validation_alias="firstName",
         serialization_alias="firstName",
-        max_length=100,
+        max_length=50,
+        pattern=CUSTOMER_NAME_PATTERN,
     )
     last_name: str = pydantic.Field(
         validation_alias="lastName",
         serialization_alias="lastName",
-        max_length=200,
+        max_length=50,
+        pattern=CUSTOMER_NAME_PATTERN,
     )
     email: pydantic.EmailStr = pydantic.Field(
         validation_alias="email",


### PR DESCRIPTION
Paytrail documents max 50 chars for firstName/lastName and rejects names
containing dots or pipe characters with an API error. Add a denylist pattern
([^|.\x00-\x1f\x7f]+) and correct max_length (100/200 → 50) in the Pydantic
Customer model so invalid input is rejected at the backend boundary.

Wire pattern/patternDescription/maxLength through SingleLineText → SchemaFormInput
→ ContactForm so the same constraint is enforced in the browser before submission,
with a localised human-readable error message via setCustomValidity() rather than
exposing the raw regex to the user.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
