### PR TITLE
feat(intra): allow granting involvement (v2) app permission

### DIFF
--- a/kompassi/intra/constants.py
+++ b/kompassi/intra/constants.py
@@ -7,4 +7,5 @@ SUPPORTED_APPS = [
     "badges",
     "intra",
     "forms",
+    "involvement",
 ]

--- a/kompassi/intra/forms.py
+++ b/kompassi/intra/forms.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from crispy_forms.layout import Fieldset, Layout
-from django import forms
+from django import forms as django_forms
 from django.contrib.auth.models import AbstractUser
 from django.utils.translation import gettext_lazy as _
 
@@ -16,8 +16,8 @@ from .constants import SUPPORTED_APPS
 from .models import Team, TeamMember
 
 
-class TeamMemberForm(forms.ModelForm):
-    job_title = forms.CharField(
+class TeamMemberForm(django_forms.ModelForm):
+    job_title = django_forms.CharField(
         max_length=JOB_TITLE_LENGTH,
         label=_("Job title"),
         required=False,
@@ -107,49 +107,54 @@ class TeamMemberForm(forms.ModelForm):
         )
 
 
-class PrivilegesForm(forms.Form):
-    labour = forms.BooleanField(
+class PrivilegesForm(django_forms.Form):
+    labour = django_forms.BooleanField(
         required=False,
         label=_("Labour admin"),
         help_text=_(
             "The Labour admin can approve or reject volunteer worker applications, assign workers to shifts etc."
         ),
     )
-    programme = forms.BooleanField(
+    programme = django_forms.BooleanField(
         required=False,
         label=_("Programme admin"),
         help_text=_(
             "The Programme admin can approve or reject programme offers, modify the event programme schedule etc."
         ),
     )
-    program_v2 = forms.BooleanField(
+    program_v2 = django_forms.BooleanField(
         required=False,
         label=_("Program v2 admin"),
         help_text=_(
             "The Program admin can approve or reject program offers, modify the event program schedule etc. in Program V2."
         ),
     )
-    tickets = forms.BooleanField(
+    tickets = django_forms.BooleanField(
         required=False,
         label=_("Tickets admin"),
         help_text=_("The Tickets admin can view, cancel and modify ticket orders and exchange electronic tickets."),
     )
-    tickets_v2 = forms.BooleanField(
+    tickets_v2 = django_forms.BooleanField(
         required=False,
         label=_("Tickets v2 admin"),
         help_text=_("The Tickets admin can view, cancel and modify ticket orders and exchange electronic tickets."),
     )
-    badges = forms.BooleanField(
+    badges = django_forms.BooleanField(
         required=False,
         label=_("Badges admin"),
         help_text=_("The Badges admin can add and revoke badges and export entrance lists."),
     )
-    intra = forms.BooleanField(
+    intra = django_forms.BooleanField(
         required=False,
         label=_("Intra admin"),
         help_text=_("The Intra admin can assign organizers to teams and manage these privileges."),
     )
-    forms = forms.BooleanField(
+    involvement = django_forms.BooleanField(
+        required=False,
+        label=_("Involvement admin"),
+        help_text=_("The Involvement admin can view and manage the people involved in the event."),
+    )
+    forms = django_forms.BooleanField(
         required=False,
         label=_("Surveys admin"),
         help_text=_("The Surveys admin can manage surveys and view survey responses."),

--- a/kompassi/intra/locale/fi/LC_MESSAGES/django.po
+++ b/kompassi/intra/locale/fi/LC_MESSAGES/django.po
@@ -258,3 +258,12 @@ msgstr "Liput v2"
 
 msgid "Program v2"
 msgstr "Ohjelma v2"
+
+msgid "Involvement"
+msgstr "Osallistuminen"
+
+msgid "Involvement admin"
+msgstr "Osallistumisen ylläpitäjä"
+
+msgid "The Involvement admin can view and manage the people involved in the event."
+msgstr "Osallistumisen ylläpitäjä voi tarkastella ja hallita tapahtumaan osallistuvia henkilöitä."

--- a/kompassi/intra/tests.py
+++ b/kompassi/intra/tests.py
@@ -1,5 +1,11 @@
 from django.test import TestCase
 
+from kompassi.access.models import CBACEntry
+from kompassi.core.models import Person
+from kompassi.event_log_v2.models.entry import Entry
+from kompassi.involvement.models.meta import InvolvementEventMeta
+
+from .forms import PrivilegesForm
 from .models import IntraEventMeta, TeamMember
 
 
@@ -19,3 +25,42 @@ class TeamMembersTestCase(TestCase):
         team_member.delete()
 
         assert not person.user.groups.filter(id=group.id).exists()
+
+
+class InvolvementPrivilegeTestCase(TestCase):
+    def setUp(self):
+        Entry.ensure_partitions()
+        self.meta, _ = IntraEventMeta.get_or_create_dummy()
+        self.event = self.meta.event
+        self.involvement_meta = InvolvementEventMeta.ensure(self.event)
+        self.person, _ = Person.get_or_create_dummy(superuser=False)
+        self.user = self.person.user
+
+    def _save_privileges(self, involvement_admin: bool):
+        active_apps = self.meta.get_active_apps()
+        assert "involvement" in active_apps
+        cleaned_data = {app_label: (app_label == "involvement" and involvement_admin) for app_label in active_apps}
+        PrivilegesForm._save(self.event, [(self.user, cleaned_data)])
+
+    def _involvement_cbac_entries(self):
+        return CBACEntry.objects.filter(
+            user=self.user,
+            claims__app="involvement",
+            claims__organization=self.event.organization.slug,
+        )
+
+    def test_grant_and_revoke_involvement_privilege(self):
+        admin_group = self.event.involvement_event_meta.admin_group
+
+        assert not admin_group.user_set.filter(id=self.user.id).exists()
+        assert not self._involvement_cbac_entries().exists()
+
+        # grant
+        self._save_privileges(involvement_admin=True)
+        assert admin_group.user_set.filter(id=self.user.id).exists()
+        assert self._involvement_cbac_entries().exists()
+
+        # revoke
+        self._save_privileges(involvement_admin=False)
+        assert not admin_group.user_set.filter(id=self.user.id).exists()
+        assert not self._involvement_cbac_entries().exists()

--- a/kompassi/intra/views/intra_admin_privileges_view.py
+++ b/kompassi/intra/views/intra_admin_privileges_view.py
@@ -17,6 +17,7 @@ APP_NAMES = dict(
     badges=_("Badges"),
     intra=_("Intra"),
     forms=_("Surveys"),
+    involvement=_("Involvement"),
 )
 
 

--- a/kompassi/involvement/migrations/0010_involvementeventmeta_admin_group.py
+++ b/kompassi/involvement/migrations/0010_involvementeventmeta_admin_group.py
@@ -1,0 +1,49 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def create_admin_groups(apps, schema_editor):
+    InvolvementEventMeta = apps.get_model("involvement", "InvolvementEventMeta")
+    Group = apps.get_model("auth", "Group")
+
+    for meta in InvolvementEventMeta.objects.select_related("event").all():
+        # Mirrors GroupManagementMixin.make_group_name for app_label "involvement".
+        group_name = f"{settings.KOMPASSI_INSTALLATION_SLUG}-{meta.event.slug}-involvement-admins"
+        group, _ = Group.objects.get_or_create(name=group_name)
+        meta.admin_group = group
+        meta.save(update_fields=["admin_group"])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+        ("involvement", "0009_involvementeventmeta_shirts_frozen_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="involvementeventmeta",
+            name="admin_group",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="+",
+                to="auth.group",
+            ),
+        ),
+        migrations.RunPython(create_admin_groups, noop),
+        migrations.AlterField(
+            model_name="involvementeventmeta",
+            name="admin_group",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="+",
+                to="auth.group",
+            ),
+        ),
+    ]

--- a/kompassi/involvement/models/meta.py
+++ b/kompassi/involvement/models/meta.py
@@ -6,10 +6,12 @@ from functools import cached_property
 from itertools import groupby
 from typing import TYPE_CHECKING
 
+from django.contrib.auth.models import Group
 from django.db import models
 from django.utils.timezone import now
 
 from kompassi.core.models.event import Event
+from kompassi.core.models.group_management_mixin import GroupManagementMixin
 from kompassi.core.utils.log_utils import log_get_or_create
 from kompassi.dimensions.models.annotation_dto import AnnotationDTO
 from kompassi.dimensions.models.dimension_dto import DimensionDTO
@@ -29,12 +31,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class InvolvementEventMeta(models.Model):
+class InvolvementEventMeta(models.Model, GroupManagementMixin):
     event: models.OneToOneField[Event] = models.OneToOneField(
         Event,
         on_delete=models.CASCADE,
         related_name="+",  # reverse being None throws DoesNotExist, we don't want that
     )
+
+    admin_group: models.ForeignKey[Group] = models.ForeignKey(
+        "auth.Group",
+        on_delete=models.CASCADE,
+        related_name="+",
+    )
+    admin_group_id: int
 
     universe: models.OneToOneField[Universe] = models.OneToOneField(
         Universe,
@@ -109,10 +118,13 @@ class InvolvementEventMeta(models.Model):
         universe = get_involvement_universe(event)
         setup_involvement_dimensions(universe, event)
 
+        (admin_group,) = cls.get_or_create_groups(event, ["admins"])
+
         meta, created = cls.objects.get_or_create(
             event=event,
             defaults=dict(
                 universe=universe,
+                admin_group=admin_group,
                 default_registry=Registry.objects.get_or_create(
                     scope=event.organization.scope,
                     slug="volunteers",
@@ -125,6 +137,10 @@ class InvolvementEventMeta(models.Model):
         )
 
         log_get_or_create(logger, meta, created)
+
+        if not created and meta.admin_group_id is None:
+            meta.admin_group = admin_group
+            meta.save(update_fields=["admin_group"])
 
         Emperkelator = meta.emperkelator_class
         if Emperkelator is not None:


### PR DESCRIPTION
InvolvementEventMeta was a plain model without an admin_group, so intra
admins had no way to grant CBAC access to the involvement (People) admin.

Give InvolvementEventMeta an admin_group (via GroupManagementMixin),
backfill groups for existing metas, and add "involvement" to the intra
Privileges page's grantable apps. Ticking the box now materializes a
CBAC entry with claims {organization, app=involvement}, which unlocks the
involvement resolvers (resolve_people, resolve_person, ...).

Fixes #984

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
