### PR TITLE
feat(forms): derive key fields from per-field isKeyField flag

### DIFF
--- a/kompassi-v2-frontend/src/__generated__/graphql.ts
+++ b/kompassi-v2-frontend/src/__generated__/graphql.ts
@@ -953,7 +953,7 @@ export type FullSurveyType = {
   /** Will attempt to give the form in the requested language, falling back to another language if that language is not available. */
   form?: Maybe<FormType>;
   isActive: Scalars['Boolean']['output'];
-  /** Key fields will be shown in the response list. */
+  /** The slugs of the fields that are designated as key fields (isKeyField). Key fields are shown in the response list. */
   keyFields: Array<Scalars['String']['output']>;
   languages: Array<FormType>;
   loginRequired: Scalars['Boolean']['output'];

--- a/kompassi-v2-frontend/src/components/forms/editFieldForm.ts
+++ b/kompassi-v2-frontend/src/components/forms/editFieldForm.ts
@@ -40,6 +40,12 @@ export function getFieldEditorFields(
       required: false,
       ...t.required,
     },
+    {
+      type: "SingleCheckbox",
+      slug: "isKeyField",
+      required: false,
+      ...t.isKeyField,
+    },
   ]);
 
   const choicesField: Field = {

--- a/kompassi-v2-frontend/src/components/forms/models.ts
+++ b/kompassi-v2-frontend/src/components/forms/models.ts
@@ -73,6 +73,7 @@ interface BaseField {
   helpText?: ReactNode;
   required?: boolean;
   readOnly?: boolean;
+  isKeyField?: boolean;
   htmlType?: HtmlType;
   encryptTo?: string[];
 }

--- a/kompassi-v2-frontend/src/translations/en.tsx
+++ b/kompassi-v2-frontend/src/translations/en.tsx
@@ -247,6 +247,10 @@ const translations = {
       required: {
         title: "Required",
       },
+      isKeyField: {
+        title: "Key field",
+        helpText: "Key fields are shown in the response list.",
+      },
       choices: {
         title: "Choices",
         helpText:

--- a/kompassi-v2-frontend/src/translations/fi.tsx
+++ b/kompassi-v2-frontend/src/translations/fi.tsx
@@ -254,6 +254,10 @@ const translations: Translations = {
       required: {
         title: "Pakollinen",
       },
+      isKeyField: {
+        title: "Avainkenttä",
+        helpText: "Avainkentät näytetään vastauslistassa.",
+      },
       choices: {
         title: "Vaihtoehdot",
         helpText:

--- a/kompassi-v2-frontend/src/translations/sv.tsx
+++ b/kompassi-v2-frontend/src/translations/sv.tsx
@@ -244,6 +244,10 @@ const translations: Translations = {
       required: {
         title: "Obligatoriskt",
       },
+      isKeyField: {
+        title: "Nyckelfält",
+        helpText: "Nyckelfält visas i svarslistan.",
+      },
       choices: {
         title: "Val",
         helpText:

--- a/kompassi/events/cosmocon2025/forms/artist-alley-application-fi.yml
+++ b/kompassi/events/cosmocon2025/forms/artist-alley-application-fi.yml
@@ -17,6 +17,7 @@ description: |
 
 fields:
   - slug: name
+    isKeyField: true
     title: Nimi ja nimimerkki
     type: SingleLineText
     required: true
@@ -61,6 +62,7 @@ fields:
     required: true
 
   - slug: day
+    isKeyField: true
     title: Haen
     type: SingleSelect
     required: true
@@ -83,6 +85,7 @@ fields:
     required: false
 
   - slug: email
+    isKeyField: true
     title: Sähköpostiosoitteesi, josta tavoitamme sinut mikäli tulet valituksi taidekujalle
     type: SingleLineText
     required: true
@@ -93,6 +96,7 @@ fields:
     required: true
 
   - slug: reserve
+    isKeyField: true
     title: Oletko valmis ottamaan vastaan peruutuspaikan varasijalta?
     type: SingleSelect
     required: true

--- a/kompassi/events/cosmocon2025/forms/cosplay-competition-application-fi.yml
+++ b/kompassi/events/cosmocon2025/forms/cosplay-competition-application-fi.yml
@@ -12,11 +12,13 @@ description: |
 
 fields:
   - slug: name
+    isKeyField: true
     title: Kilpailijan nimi tai nimimerkki
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Sähköpostiosoite
     type: SingleLineText
     required: true
@@ -27,6 +29,7 @@ fields:
     required: true
 
   - slug: character
+    isKeyField: true
     title: Cossattavan hahmon nimi
     type: SingleLineText
     required: true
@@ -75,6 +78,7 @@ fields:
         title: Kyllä
 
   - slug: reserve
+    isKeyField: true
     title: Mikäli en tule heti valituksi, haluan jäädä varasijalle siltä varalta, että joku valituista kisaajista jää kisasta pois.
     type: SingleSelect
     required: true

--- a/kompassi/events/cosmocon2025/management/commands/setup_cosmocon2025.py
+++ b/kompassi/events/cosmocon2025/management/commands/setup_cosmocon2025.py
@@ -397,7 +397,7 @@ class Setup:
                 active_from=datetime(2024, 10, 21, 0, 0, tzinfo=self.tz),
                 active_until=datetime(2024, 11, 8, 0, 0, tzinfo=self.tz),
                 max_responses_per_user=1,
-                key_fields=["name", "email", "day", "reserve"],
+                cached_key_fields=["name", "email", "day", "reserve"],
                 login_required=True,
             ),
         )
@@ -421,7 +421,7 @@ class Setup:
                 active_from=datetime(2024, 11, 1, 0, 0, tzinfo=self.tz),
                 active_until=datetime(2024, 12, 16, 0, 0, tzinfo=self.tz),
                 max_responses_per_user=1,
-                key_fields=["name", "email", "character", "reserve"],
+                cached_key_fields=["name", "email", "character", "reserve"],
                 login_required=True,
             ),
         )

--- a/kompassi/events/cosmocon2025/management/commands/setup_cosmocon2025.py
+++ b/kompassi/events/cosmocon2025/management/commands/setup_cosmocon2025.py
@@ -397,18 +397,18 @@ class Setup:
                 active_from=datetime(2024, 10, 21, 0, 0, tzinfo=self.tz),
                 active_until=datetime(2024, 11, 8, 0, 0, tzinfo=self.tz),
                 max_responses_per_user=1,
-                cached_key_fields=["name", "email", "day", "reserve"],
                 login_required=True,
             ),
         )
 
         forms_path = Path(__file__).parent.parent.parent / "forms"
-        Form.objects.get_or_create(
+        artist_alley_application_fi, _ = Form.objects.get_or_create(
             event=self.event,
             survey=artist_alley_application,
             language="fi",
             defaults=yaml.safe_load((forms_path / "artist-alley-application-fi.yml").read_text()),
         )
+        artist_alley_application.refresh_cached_key_fields(artist_alley_application_fi)
 
         for dimension in yaml.safe_load((forms_path / "artist-alley-application-dimensions.yml").read_text()):
             DimensionDTO.model_validate(dimension).save(artist_alley_application.universe)
@@ -421,16 +421,16 @@ class Setup:
                 active_from=datetime(2024, 11, 1, 0, 0, tzinfo=self.tz),
                 active_until=datetime(2024, 12, 16, 0, 0, tzinfo=self.tz),
                 max_responses_per_user=1,
-                cached_key_fields=["name", "email", "character", "reserve"],
                 login_required=True,
             ),
         )
-        Form.objects.get_or_create(
+        cosplay_competition_application_fi, _ = Form.objects.get_or_create(
             event=self.event,
             survey=cosplay_competition_application,
             language="fi",
             defaults=yaml.safe_load((forms_path / "cosplay-competition-application-fi.yml").read_text()),
         )
+        cosplay_competition_application.refresh_cached_key_fields(cosplay_competition_application_fi)
 
         for dimension in yaml.safe_load((forms_path / "cosplay-competition-application-dimensions.yml").read_text()):
             DimensionDTO.model_validate(dimension).save(cosplay_competition_application.universe)

--- a/kompassi/events/hitpoint2024/forms/larp-survey-en.yml
+++ b/kompassi/events/hitpoint2024/forms/larp-survey-en.yml
@@ -15,6 +15,7 @@ fields:
     slug: background
 
   - slug: participated_in_tracon_hitpoint
+    isKeyField: true
     title: How many times have you participated in Tracon Hitpoint?
     helpText: "Tracon Hitpoint has been organized four times: in 2015, 2017, 2019 and 2024."
     type: NumberField

--- a/kompassi/events/hitpoint2024/forms/larp-survey-fi.yml
+++ b/kompassi/events/hitpoint2024/forms/larp-survey-fi.yml
@@ -15,6 +15,7 @@ fields:
     slug: background
 
   - slug: participated_in_tracon_hitpoint
+    isKeyField: true
     title: Montako kertaa olet osallistunut Tracon Hitpointiin?
     helpText: "Tracon Hitpoint on järjestetty neljä kertaa: vuosina 2015, 2017, 2019 ja 2024."
     type: NumberField

--- a/kompassi/events/hitpoint2024/management/commands/setup_hitpoint2024.py
+++ b/kompassi/events/hitpoint2024/management/commands/setup_hitpoint2024.py
@@ -572,16 +572,14 @@ class Setup:
         with resource_stream("events.hitpoint2024", "forms/larp-survey-en.yml") as f:
             data = yaml.safe_load(f)
 
-        Form.objects.update_or_create(
+        en_form, _ = Form.objects.update_or_create(
             event=self.event,
             survey=survey,
             language="en",
             defaults=data,
         )
 
-        if not survey.cached_key_fields:
-            survey.cached_key_fields = ["participated_in_tracon_hitpoint"]
-            survey.save()
+        survey.refresh_cached_key_fields(en_form)
 
 
 class Command(BaseCommand):

--- a/kompassi/events/hitpoint2024/management/commands/setup_hitpoint2024.py
+++ b/kompassi/events/hitpoint2024/management/commands/setup_hitpoint2024.py
@@ -579,8 +579,8 @@ class Setup:
             defaults=data,
         )
 
-        if not survey.key_fields:
-            survey.key_fields = ["participated_in_tracon_hitpoint"]
+        if not survey.cached_key_fields:
+            survey.cached_key_fields = ["participated_in_tracon_hitpoint"]
             survey.save()
 
 

--- a/kompassi/events/kotaeexpo2025/forms/expense-claim-en.yml
+++ b/kompassi/events/kotaeexpo2025/forms/expense-claim-en.yml
@@ -11,6 +11,7 @@ description: |
 
 fields:
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Title
     required: true
@@ -23,6 +24,7 @@ fields:
       If the title does not tell everything essential, you can provide additional information here.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/kotaeexpo2025/forms/expense-claim-fi.yml
+++ b/kompassi/events/kotaeexpo2025/forms/expense-claim-fi.yml
@@ -10,6 +10,7 @@ description: |
 
 fields:
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Otsikko
     required: true
@@ -22,6 +23,7 @@ fields:
       Jos otsikko ei kerro kaikkea olennaista, voit antaa tässä lisätietoja.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/kotaeexpo2025/management/commands/setup_kotaeexpo2025.py
+++ b/kompassi/events/kotaeexpo2025/management/commands/setup_kotaeexpo2025.py
@@ -288,7 +288,6 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
                 active_from=datetime(2025, 1, 1, 0, 0, tzinfo=self.tz),

--- a/kompassi/events/kotaeexpo2025/management/commands/setup_kotaeexpo2025.py
+++ b/kompassi/events/kotaeexpo2025/management/commands/setup_kotaeexpo2025.py
@@ -288,7 +288,7 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                key_fields=["title", "amount"],
+                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
                 active_from=datetime(2025, 1, 1, 0, 0, tzinfo=self.tz),

--- a/kompassi/events/kotaeexpo2026/forms/expense-claim-en.yml
+++ b/kompassi/events/kotaeexpo2026/forms/expense-claim-en.yml
@@ -11,6 +11,7 @@ description: |
 
 fields:
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Title
     required: true
@@ -23,6 +24,7 @@ fields:
       If the title does not tell everything essential, you can provide additional information here.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/kotaeexpo2026/forms/expense-claim-fi.yml
+++ b/kompassi/events/kotaeexpo2026/forms/expense-claim-fi.yml
@@ -10,6 +10,7 @@ description: |
 
 fields:
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Otsikko
     required: true
@@ -22,6 +23,7 @@ fields:
       Jos otsikko ei kerro kaikkea olennaista, voit antaa tässä lisätietoja.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/kotaeexpo2026/management/commands/setup_kotaeexpo2026.py
+++ b/kompassi/events/kotaeexpo2026/management/commands/setup_kotaeexpo2026.py
@@ -314,7 +314,7 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                key_fields=["title", "amount"],
+                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
                 active_from=datetime(2026, 1, 1, 0, 0, tzinfo=self.tz),

--- a/kompassi/events/kotaeexpo2026/management/commands/setup_kotaeexpo2026.py
+++ b/kompassi/events/kotaeexpo2026/management/commands/setup_kotaeexpo2026.py
@@ -314,7 +314,6 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
                 active_from=datetime(2026, 1, 1, 0, 0, tzinfo=self.tz),

--- a/kompassi/events/matsucon2024/forms/artist-alley-application-en.yml
+++ b/kompassi/events/matsucon2024/forms/artist-alley-application-en.yml
@@ -14,16 +14,19 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: First and surname
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Contact person's email
     type: SingleLineText
     required: true
 
   - slug: table_size
+    isKeyField: true
     title: Table size
     type: MultiSelect
     required: false
@@ -40,6 +43,7 @@ fields:
     required: true
 
   - slug: reserve
+    isKeyField: true
     title: Reserve list
     helpText: "Choose if you want a table if they become available. We make a list of people and send an email to those who said yes, if a table frees up. We do not publish a list of people on the list. In the free comment section you can specify how soon before the event you're able to accept a spot."
     type: SingleSelect
@@ -57,6 +61,7 @@ fields:
     slug: background_info
 
   - slug: experience
+    isKeyField: true
     title: Experience
     type: MultiSelect
     choices:
@@ -106,6 +111,7 @@ fields:
     slug: artist_info1
 
   - slug: artist_name1
+    isKeyField: true
     title: Artist name
     type: SingleLineText
     required: true

--- a/kompassi/events/matsucon2024/forms/artist-alley-application-fi.yml
+++ b/kompassi/events/matsucon2024/forms/artist-alley-application-fi.yml
@@ -14,11 +14,13 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: Etunimi ja sukunimi
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Vastuuhenkilön sähköposti
     type: SingleLineText
     required: true

--- a/kompassi/events/matsucon2024/management/commands/setup_matsucon2024.py
+++ b/kompassi/events/matsucon2024/management/commands/setup_matsucon2024.py
@@ -407,7 +407,6 @@ class Setup:
             slug="artist-alley-application",
             defaults=dict(
                 active_from=now(),
-                cached_key_fields=["name", "email", "artist_name1", "table_size", "experience", "reserve"],
                 login_required=True,
             ),
         )
@@ -432,6 +431,8 @@ class Setup:
             defaults=data,
         )
 
+        artist_alley_application.refresh_cached_key_fields(artist_alley_application_fi)
+
         with resource_stream("events.matsucon2024", "forms/artist-alley-application-dimensions.yml") as f:
             data = yaml.safe_load(f)
 
@@ -444,14 +445,6 @@ class Setup:
             slug="vendor-application",
             defaults=dict(
                 active_from=now(),
-                cached_key_fields=[
-                    "name",
-                    "email",
-                    "website",
-                    "id",
-                    "businessname",
-                    "days",
-                ],
                 login_required=True,
             ),
         )
@@ -475,6 +468,8 @@ class Setup:
             language="fi",
             defaults=data,
         )
+
+        vendor_application.refresh_cached_key_fields(vendor_application_fi)
 
         with resource_stream("events.matsucon2024", "forms/vendor-application-dimensions.yml") as f:
             data = yaml.safe_load(f)

--- a/kompassi/events/matsucon2024/management/commands/setup_matsucon2024.py
+++ b/kompassi/events/matsucon2024/management/commands/setup_matsucon2024.py
@@ -407,7 +407,7 @@ class Setup:
             slug="artist-alley-application",
             defaults=dict(
                 active_from=now(),
-                key_fields=["name", "email", "artist_name1", "table_size", "experience", "reserve"],
+                cached_key_fields=["name", "email", "artist_name1", "table_size", "experience", "reserve"],
                 login_required=True,
             ),
         )
@@ -444,7 +444,7 @@ class Setup:
             slug="vendor-application",
             defaults=dict(
                 active_from=now(),
-                key_fields=[
+                cached_key_fields=[
                     "name",
                     "email",
                     "website",

--- a/kompassi/events/tracon2024/forms/artisan-application-en.yml
+++ b/kompassi/events/tracon2024/forms/artisan-application-en.yml
@@ -11,16 +11,19 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: Contact person's first name and surname
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Contact person's email
     type: SingleLineText
     required: true
 
   - slug: helper_name
+    isKeyField: true
     title: Helper's name
     type: SingleLineText
 

--- a/kompassi/events/tracon2024/forms/artisan-application-fi.yml
+++ b/kompassi/events/tracon2024/forms/artisan-application-fi.yml
@@ -11,16 +11,19 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: Vastuuhenkilön etu- ja sukunimi
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Vastuuhenkilön sähköposti
     type: SingleLineText
     required: true
 
   - slug: helper_name
+    isKeyField: true
     title: Apumyyjän nimi
     type: SingleLineText
 

--- a/kompassi/events/tracon2024/forms/artist-alley-application-en.yml
+++ b/kompassi/events/tracon2024/forms/artist-alley-application-en.yml
@@ -12,11 +12,13 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: First name and surname
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Contact person's email
     type: SingleLineText
     required: true
@@ -57,6 +59,7 @@ fields:
     required: true
 
   - slug: reserve
+    isKeyField: true
     title: Reserve list
     helpText: "Choose if you want to be on the reserve list if tables become available. We will make a reserve list of people and send an email to those who said yes if a table frees up. We will not publish a list of people on the reserve list. In the free comment section you can specify how soon before the event you will be able to accept a table."
     type: SingleSelect
@@ -84,6 +87,7 @@ fields:
         title: First time at the Tracon event
 
   - slug: location
+    isKeyField: true
     title: Are you coming to the event from Finland or abroad
     type: SingleSelect
     required: true
@@ -109,6 +113,7 @@ fields:
     slug: artist_info1
 
   - slug: artist_name1
+    isKeyField: true
     title: Artist name
     type: SingleLineText
     required: true

--- a/kompassi/events/tracon2024/forms/artist-alley-application-fi.yml
+++ b/kompassi/events/tracon2024/forms/artist-alley-application-fi.yml
@@ -12,11 +12,13 @@ fields:
     slug: basic_info_title
 
   - slug: name
+    isKeyField: true
     title: Etunimi ja sukunimi
     type: SingleLineText
     required: true
 
   - slug: email
+    isKeyField: true
     title: Vastuuhenkilön sähköposti
     type: SingleLineText
     required: true
@@ -57,6 +59,7 @@ fields:
     required: true
 
   - slug: reserve
+    isKeyField: true
     title: Varasija
     helpText: "Ilmaise halukkuutesi varasijalle. Teemme listan varasijallisista, joita lähestytään sähköpostilla, mikäli paikkoja vapautuu. Erillistä varasijalistaa ei julkaista tai ilmoiteta. Alempana voit vapaassa kentässä täsmentää, kuinka lyhyellä ajalla olet valmis tulemaan."
     type: SingleSelect
@@ -83,6 +86,7 @@ fields:
         title: Ensikertaa Tracon -tapahtumassa
 
   - slug: location
+    isKeyField: true
     title: Osallistutko tapahtumaan Suomesta vai ulkomailta
     type: SingleSelect
     required: true
@@ -108,6 +112,7 @@ fields:
     slug: artist_info1
 
   - slug: artist_name1
+    isKeyField: true
     title: Taiteilijanimi
     type: SingleLineText
     required: true

--- a/kompassi/events/tracon2024/forms/cosplay-jury-application-fi.yml
+++ b/kompassi/events/tracon2024/forms/cosplay-jury-application-fi.yml
@@ -7,6 +7,7 @@ description: |
   Ongelmatilanteissa, ota yhteyttä <em>cosplay@tracon.fi</em> tai suoraan cosplayvastaavaan <em>chamira@tracon.fi</em>
 fields:
   - slug: performer_name
+    isKeyField: true
     type: SingleLineText
     title: Nimi / Nick, jota haluat käyttää julkisesti
     required: true

--- a/kompassi/events/tracon2024/forms/expense-claim-en.yml
+++ b/kompassi/events/tracon2024/forms/expense-claim-en.yml
@@ -17,6 +17,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Title
     required: true
@@ -29,6 +30,7 @@ fields:
       If the title does not tell everything essential, you can provide additional information here.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/tracon2024/forms/expense-claim-fi.yml
+++ b/kompassi/events/tracon2024/forms/expense-claim-fi.yml
@@ -17,6 +17,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Otsikko
     required: true
@@ -29,6 +30,7 @@ fields:
       Jos otsikko ei kerro kaikkea olennaista, voit antaa tässä lisätietoja.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/tracon2024/forms/geekjam-signup-en.yml
+++ b/kompassi/events/tracon2024/forms/geekjam-signup-en.yml
@@ -5,11 +5,13 @@ description: |
   Know how to play a (portable) instrument? Like to play together? Bring yourself and your instrument(s) to the park! We'll play geek music (possibly mixed with some Irish and other trad music) together. Some (but not all) songs may also be sing-along and there may be an electric piano. We'll prefer D whistle compatible keys (D major, G major, E minor, B minor) to allow whistles & simple system flutes to participate. Sign-up is not mandatory, but you can also use this form to suggest songs! You're also welcome to just listen.
 fields:
   - slug: nick
+    isKeyField: true
     type: SingleLineText
     title: Nick name
     required: true
 
   - slug: instruments
+    isKeyField: true
     type: MultiLineText
     title: Instrument(s)
     helpText: |

--- a/kompassi/events/tracon2024/forms/geekjam-signup-fi.yml
+++ b/kompassi/events/tracon2024/forms/geekjam-signup-fi.yml
@@ -5,10 +5,12 @@ description: |
   Soitatko jotain (mukana kuljetettavaa) soitinta? Haluaisitko soittaa porukalla? Tuo itsesi ja soittimesi puistoon! Soittelemme yhdessä matalalla kynnyksellä nörttimusiikkia (mahdollisesti höystettynä irlantilaisella ym. trad-musiikilla). Osaan biiseistä voinee yhtyä myös yhteislauluna ja saatamme tarjota myös sähköpianon. Suosimme D-pillin kanssa yhteensopivia sävellajeja (D- ja G-duuri, E- ja H-molli) jotta pilleillä ja avaimettomilla huiluilla voi soittaa mukana. Ilmoittautuminen ei ole pakollista, mutta tällä lomakkeella voit myös ehdottaa biisejä! Saa tulla myös mukaan vain kuuntelemaan.
 fields:
   - slug: nick
+    isKeyField: true
     type: SingleLineText
     title: Lempinimi
     required: true
   - slug: instruments
+    isKeyField: true
     type: MultiLineText
     title: Soittimet
     helpText: |

--- a/kompassi/events/tracon2024/forms/opening-closing-performer-application-fi.yml
+++ b/kompassi/events/tracon2024/forms/opening-closing-performer-application-fi.yml
@@ -50,6 +50,7 @@ fields:
     dimension: program
 
   - slug: performer-name
+    isKeyField: true
     type: SingleLineText
     title: Taiteilijanimi tai ryhmän nimi
     required: true

--- a/kompassi/events/tracon2024/forms/vendor-application-en.yml
+++ b/kompassi/events/tracon2024/forms/vendor-application-en.yml
@@ -12,6 +12,7 @@ fields:
     type: StaticText
 
   - slug: public_name
+    isKeyField: true
     type: SingleLineText
     title: Displayed name
     required: true

--- a/kompassi/events/tracon2024/forms/vendor-application-fi.yml
+++ b/kompassi/events/tracon2024/forms/vendor-application-fi.yml
@@ -12,6 +12,7 @@ fields:
     type: StaticText
 
   - slug: public_name
+    isKeyField: true
     type: SingleLineText
     title: Kauppanimi
     required: true

--- a/kompassi/events/tracon2024/management/commands/setup_tracon2024.py
+++ b/kompassi/events/tracon2024/management/commands/setup_tracon2024.py
@@ -895,15 +895,15 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="artisan-application",
-                key_fields=["name", "email", "helper"],
+                cached_key_fields=["name", "email", "helper"],
             ),
             SurveyDTO(
                 slug="artist-alley-application",
-                key_fields=["name", "email", "artist_name1", "location", "reserve"],
+                cached_key_fields=["name", "email", "artist_name1", "location", "reserve"],
             ),
             SurveyDTO(
                 slug="expense-claim",
-                key_fields=["title", "amount"],
+                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
@@ -911,15 +911,15 @@ class Setup:
             SurveyDTO(slug="jv-kertauskurssi"),
             SurveyDTO(
                 slug="opening-closing-performer-application",
-                key_fields=["performer-name"],
+                cached_key_fields=["performer-name"],
             ),
             SurveyDTO(
                 slug="vendor-application",
-                key_fields=["name"],
+                cached_key_fields=["name"],
             ),
             SurveyDTO(
                 slug="cosplay-jury-application",
-                key_fields=["performer_name"],
+                cached_key_fields=["performer_name"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
@@ -930,7 +930,7 @@ class Setup:
             ),
             SurveyDTO(
                 slug="geekjam-signup",
-                key_fields=["nick", "instruments"],
+                cached_key_fields=["nick", "instruments"],
             ),
         ]:
             survey.save(self.event)

--- a/kompassi/events/tracon2024/management/commands/setup_tracon2024.py
+++ b/kompassi/events/tracon2024/management/commands/setup_tracon2024.py
@@ -895,15 +895,12 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="artisan-application",
-                cached_key_fields=["name", "email", "helper"],
             ),
             SurveyDTO(
                 slug="artist-alley-application",
-                cached_key_fields=["name", "email", "artist_name1", "location", "reserve"],
             ),
             SurveyDTO(
                 slug="expense-claim",
-                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
@@ -911,15 +908,12 @@ class Setup:
             SurveyDTO(slug="jv-kertauskurssi"),
             SurveyDTO(
                 slug="opening-closing-performer-application",
-                cached_key_fields=["performer-name"],
             ),
             SurveyDTO(
                 slug="vendor-application",
-                cached_key_fields=["name"],
             ),
             SurveyDTO(
                 slug="cosplay-jury-application",
-                cached_key_fields=["performer_name"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
@@ -930,7 +924,6 @@ class Setup:
             ),
             SurveyDTO(
                 slug="geekjam-signup",
-                cached_key_fields=["nick", "instruments"],
             ),
         ]:
             survey.save(self.event)

--- a/kompassi/events/tracon2025/management/commands/setup_tracon2025.py
+++ b/kompassi/events/tracon2025/management/commands/setup_tracon2025.py
@@ -421,8 +421,8 @@ class Setup:
         survey = Survey.objects.filter(event=self.event, slug="program-feedback").first()
         if survey:
             # derp
-            survey.key_fields = []
-            survey.save(update_fields=["key_fields"])
+            survey.cached_key_fields = []
+            survey.save(update_fields=["cached_key_fields"])
 
             dimension = DimensionDTO(
                 slug="program",
@@ -864,13 +864,13 @@ class Setup:
             # ),
             # SurveyDTO(
             #     slug="expense-claim",
-            #     key_fields=["title", "amount"],
+            #     cached_key_fields=["title", "amount"],
             #     login_required=True,
             #     anonymity="NAME_AND_EMAIL",
             # ),
             # SurveyDTO(
             #     slug="car-usage",
-            #     key_fields=["title", "kilometers"],
+            #     cached_key_fields=["title", "kilometers"],
             #     login_required=True,
             #     anonymity="NAME_AND_EMAIL",
             # ),

--- a/kompassi/events/tracon2025/management/commands/setup_tracon2025.py
+++ b/kompassi/events/tracon2025/management/commands/setup_tracon2025.py
@@ -420,9 +420,9 @@ class Setup:
         return
         survey = Survey.objects.filter(event=self.event, slug="program-feedback").first()
         if survey:
-            # derp
-            survey.cached_key_fields = []
-            survey.save(update_fields=["cached_key_fields"])
+            first_form = survey.languages.order_by("pk").first()
+            if first_form is not None:
+                survey.refresh_cached_key_fields(first_form)
 
             dimension = DimensionDTO(
                 slug="program",
@@ -864,13 +864,11 @@ class Setup:
             # ),
             # SurveyDTO(
             #     slug="expense-claim",
-            #     cached_key_fields=["title", "amount"],
             #     login_required=True,
             #     anonymity="NAME_AND_EMAIL",
             # ),
             # SurveyDTO(
             #     slug="car-usage",
-            #     cached_key_fields=["title", "kilometers"],
             #     login_required=True,
             #     anonymity="NAME_AND_EMAIL",
             # ),

--- a/kompassi/events/tracon2026/forms/car-usage-en.yml
+++ b/kompassi/events/tracon2026/forms/car-usage-en.yml
@@ -18,6 +18,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Title
     required: true
@@ -30,6 +31,7 @@ fields:
       Extra information about the travel, e.g. where you drove from and to, who was with you, etc.
 
   - slug: kilometers
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 0

--- a/kompassi/events/tracon2026/forms/car-usage-fi.yml
+++ b/kompassi/events/tracon2026/forms/car-usage-fi.yml
@@ -18,6 +18,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Otsikko
     required: true
@@ -30,6 +31,7 @@ fields:
       Lisätietoja matkasta, esimerkiksi mistä minne ajoit, kuka oli mukana jne.
 
   - slug: kilometers
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 0

--- a/kompassi/events/tracon2026/forms/expense-claim-en.yml
+++ b/kompassi/events/tracon2026/forms/expense-claim-en.yml
@@ -19,6 +19,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Title
     required: true
@@ -31,6 +32,7 @@ fields:
       If the title does not tell everything essential, you can provide additional information here.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/tracon2026/forms/expense-claim-fi.yml
+++ b/kompassi/events/tracon2026/forms/expense-claim-fi.yml
@@ -20,6 +20,7 @@ fields:
     dimension: event
 
   - slug: title
+    isKeyField: true
     type: SingleLineText
     title: Otsikko
     required: true
@@ -32,6 +33,7 @@ fields:
       Jos otsikko ei kerro kaikkea olennaista, voit antaa tässä lisätietoja.
 
   - slug: amount
+    isKeyField: true
     type: DecimalField
     minValue: 0
     decimalPlaces: 2

--- a/kompassi/events/tracon2026/management/commands/setup_tracon2026.py
+++ b/kompassi/events/tracon2026/management/commands/setup_tracon2026.py
@@ -800,13 +800,11 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
             SurveyDTO(
                 slug="car-usage",
-                cached_key_fields=["title", "kilometers"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),

--- a/kompassi/events/tracon2026/management/commands/setup_tracon2026.py
+++ b/kompassi/events/tracon2026/management/commands/setup_tracon2026.py
@@ -800,13 +800,13 @@ class Setup:
         for survey in [
             SurveyDTO(
                 slug="expense-claim",
-                key_fields=["title", "amount"],
+                cached_key_fields=["title", "amount"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),
             SurveyDTO(
                 slug="car-usage",
-                key_fields=["title", "kilometers"],
+                cached_key_fields=["title", "kilometers"],
                 login_required=True,
                 anonymity="NAME_AND_EMAIL",
             ),

--- a/kompassi/forms/admin.py
+++ b/kompassi/forms/admin.py
@@ -71,8 +71,9 @@ class SurveyAdmin(admin.ModelAdmin):
         "max_responses_per_user",
         "active_from",
         "active_until",
-        "key_fields",
+        "cached_key_fields",
     )
+    readonly_fields = ("cached_key_fields",)
 
 
 @admin.register(Projection)

--- a/kompassi/forms/graphql/mutations/create_survey_language.py
+++ b/kompassi/forms/graphql/mutations/create_survey_language.py
@@ -1,4 +1,5 @@
 import graphene
+from django.db import transaction
 
 from kompassi.access.cbac import graphql_check_instance
 from kompassi.dimensions.models.enums import DimensionApp
@@ -30,39 +31,40 @@ class CreateSurveyLanguage(graphene.Mutation):
         info,
         input: CreateSurveyLanguageInput,
     ):
-        survey = Survey.objects.get(event__slug=input.event_slug, slug=input.survey_slug)
-        graphql_check_instance(
-            survey,
-            info,
-            app=survey.app_name,
-            field="languages",
-            operation="create",
-        )
-
-        language: str = input.language  # type: ignore
-        if language not in SUPPORTED_LANGUAGE_CODES:
-            raise ValueError(f"Unsupported language: {language}")
-
-        if input.copy_from:
-            form = survey.languages.get(language=input.copy_from)
-            form.pk = None
-            form.language = input.language
-            form.created_by = info.context.user
-            form.save()
-        else:
-            if survey.app == DimensionApp.PROGRAM_V2 and survey.purpose == SurveyPurpose.DEFAULT:
-                fields = get_program_offer_form_default_fields(language)
-            else:
-                fields = []
-
-            form = Form.objects.create(
-                event=survey.event,
-                survey=survey,
-                language=input.language,
-                created_by=info.context.user,
-                fields=fields,
+        with transaction.atomic():
+            survey = Survey.objects.get(event__slug=input.event_slug, slug=input.survey_slug)
+            graphql_check_instance(
+                survey,
+                info,
+                app=survey.app_name,
+                field="languages",
+                operation="create",
             )
 
-        survey.refresh_cached_key_fields(form)
-        survey.workflow.handle_form_update()
-        return CreateSurveyLanguage(form=form)  # type: ignore
+            language: str = input.language  # type: ignore
+            if language not in SUPPORTED_LANGUAGE_CODES:
+                raise ValueError(f"Unsupported language: {language}")
+
+            if input.copy_from:
+                form = survey.languages.get(language=input.copy_from)
+                form.pk = None
+                form.language = input.language
+                form.created_by = info.context.user
+                form.save()
+            else:
+                if survey.app == DimensionApp.PROGRAM_V2 and survey.purpose == SurveyPurpose.DEFAULT:
+                    fields = get_program_offer_form_default_fields(language)
+                else:
+                    fields = []
+
+                form = Form.objects.create(
+                    event=survey.event,
+                    survey=survey,
+                    language=input.language,
+                    created_by=info.context.user,
+                    fields=fields,
+                )
+
+            survey.refresh_cached_key_fields(form)
+            survey.workflow.handle_form_update()
+            return CreateSurveyLanguage(form=form)  # type: ignore

--- a/kompassi/forms/graphql/mutations/create_survey_language.py
+++ b/kompassi/forms/graphql/mutations/create_survey_language.py
@@ -63,5 +63,6 @@ class CreateSurveyLanguage(graphene.Mutation):
                 fields=fields,
             )
 
+        survey.refresh_cached_key_fields(form)
         survey.workflow.handle_form_update()
         return CreateSurveyLanguage(form=form)  # type: ignore

--- a/kompassi/forms/graphql/mutations/update_form_fields.py
+++ b/kompassi/forms/graphql/mutations/update_form_fields.py
@@ -47,4 +47,6 @@ class UpdateFormFields(graphene.Mutation):
         form.fields = [field.model_dump(mode="json", by_alias=True) for field in fields.fields]
         form.save(update_fields=["fields", "cached_enriched_fields"])
 
+        survey.refresh_cached_key_fields(form)
+
         return UpdateFormFields(survey=survey)  # type: ignore

--- a/kompassi/forms/graphql/mutations/update_form_fields.py
+++ b/kompassi/forms/graphql/mutations/update_form_fields.py
@@ -1,5 +1,6 @@
 import graphene
 import pydantic
+from django.db import transaction
 from graphene.types.generic import GenericScalar
 
 from kompassi.access.cbac import graphql_check_instance
@@ -32,21 +33,22 @@ class UpdateFormFields(graphene.Mutation):
         info,
         input: UpdateFormFieldsInput,
     ):
-        survey = Survey.objects.get(event__slug=input.event_slug, slug=input.survey_slug)
-        form = survey.languages.get(language=input.language)
-        fields = Fields.model_validate(dict(fields=input.fields))
+        with transaction.atomic():
+            survey = Survey.objects.get(event__slug=input.event_slug, slug=input.survey_slug)
+            form = survey.languages.get(language=input.language)
+            fields = Fields.model_validate(dict(fields=input.fields))
 
-        graphql_check_instance(
-            survey,
-            info,
-            app=survey.app_name,
-            field="languages",
-            operation="update",
-        )
+            graphql_check_instance(
+                survey,
+                info,
+                app=survey.app_name,
+                field="languages",
+                operation="update",
+            )
 
-        form.fields = [field.model_dump(mode="json", by_alias=True) for field in fields.fields]
-        form.save(update_fields=["fields", "cached_enriched_fields"])
+            form.fields = [field.model_dump(mode="json", by_alias=True) for field in fields.fields]
+            form.save(update_fields=["fields", "cached_enriched_fields"])
 
-        survey.refresh_cached_key_fields(form)
+            survey.refresh_cached_key_fields(form)
 
-        return UpdateFormFields(survey=survey)  # type: ignore
+            return UpdateFormFields(survey=survey)  # type: ignore

--- a/kompassi/forms/graphql/survey_full.py
+++ b/kompassi/forms/graphql/survey_full.py
@@ -56,7 +56,7 @@ class FullSurveyType(LimitedSurveyType):
         fields = parent.get_combined_fields(lang)
 
         if key_fields_only:
-            fields = (field for field in fields if field.slug in parent.key_fields)
+            fields = (field for field in fields if field.slug in parent.cached_key_fields)
 
         return [
             field.model_dump(
@@ -71,6 +71,19 @@ class FullSurveyType(LimitedSurveyType):
         lang=graphene.String(),
         key_fields_only=graphene.Boolean(),
         description=normalize_whitespace(resolve_fields.__doc__ or ""),
+    )
+
+    @staticmethod
+    def resolve_key_fields(survey: Survey, info):
+        """
+        The slugs of the fields that are designated as key fields (isKeyField).
+        Key fields are shown in the response list.
+        """
+        return survey.cached_key_fields
+
+    key_fields = graphene.NonNull(
+        graphene.List(graphene.NonNull(graphene.String)),
+        description=normalize_whitespace(resolve_key_fields.__doc__ or ""),
     )
 
     @staticmethod
@@ -266,7 +279,6 @@ class FullSurveyType(LimitedSurveyType):
             "active_until",
             "responses_editable_until",
             "languages",
-            "key_fields",
             "login_required",
             "anonymity",
             "max_responses_per_user",

--- a/kompassi/forms/migrations/0055_rename_survey_key_fields_cached_key_fields.py
+++ b/kompassi/forms/migrations/0055_rename_survey_key_fields_cached_key_fields.py
@@ -1,0 +1,58 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+
+def backfill_is_key_field(apps, schema_editor):
+    """
+    cached_key_fields used to be an authoritative, directly-edited list of field slugs.
+    It is now denormalized from the isKeyField flag of the form fields. Backfill that flag
+    into existing form fields so a later form edit does not wipe existing key fields.
+    """
+    Survey = apps.get_model("forms", "Survey")
+
+    for survey in Survey.objects.exclude(cached_key_fields=[]).prefetch_related("languages"):
+        key_field_slugs = set(survey.cached_key_fields)
+        for form in survey.languages.all():
+            changed = False
+            for field_list in (form.fields, form.cached_enriched_fields):
+                for field in field_list:
+                    if field.get("slug") in key_field_slugs and not field.get("isKeyField"):
+                        field["isKeyField"] = True
+                        changed = True
+            if changed:
+                form.save(update_fields=["fields", "cached_enriched_fields"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("forms", "0054_projection_special_fields"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="survey",
+            old_name="key_fields",
+            new_name="cached_key_fields",
+        ),
+        migrations.AlterField(
+            model_name="survey",
+            name="cached_key_fields",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=255),
+                blank=True,
+                default=list,
+                help_text=(
+                    "Key fields will be shown in the response list. "
+                    "This field is denormalized from the isKeyField flag of the form fields "
+                    "and should not be edited directly."
+                ),
+                size=None,
+                verbose_name="key fields",
+            ),
+        ),
+        migrations.RunPython(
+            code=backfill_is_key_field,
+            reverse_code=migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/kompassi/forms/models/field.py
+++ b/kompassi/forms/models/field.py
@@ -118,6 +118,12 @@ class Field(pydantic.BaseModel, populate_by_name=True):
         serialization_alias="readOnly",
         repr=False,
     )
+    is_key_field: bool | None = pydantic.Field(
+        default=None,
+        validation_alias="isKeyField",
+        serialization_alias="isKeyField",
+        repr=False,
+    )
 
     # TODO silly union of all field types. refactor this into proper (GraphQL?) types
     # dimension and subsetValues only make sense for DimensionSingleSelect, DimensionMultiSelect

--- a/kompassi/forms/models/response.py
+++ b/kompassi/forms/models/response.py
@@ -194,11 +194,11 @@ class Response(models.Model):
         if fields is None:
             raise AssertionError("This should never happen (appease type checker)")
 
-        values, warnings = self.get_processed_form_data(fields, field_slugs=self.survey.key_fields)
+        values, warnings = self.get_processed_form_data(fields, field_slugs=self.survey.cached_key_fields)
         return {
             field_slug: field_value
             for field_slug, field_value in values.items()
-            if field_slug in self.survey.key_fields and field_slug not in warnings and field_value is not None
+            if field_slug in self.survey.cached_key_fields and field_slug not in warnings and field_value is not None
         }
 
     def _build_cached_dimensions(self) -> dict[str, list[str]]:

--- a/kompassi/forms/models/survey.py
+++ b/kompassi/forms/models/survey.py
@@ -306,6 +306,7 @@ class Survey(models.Model):
         so the flag is also synced to the other language versions.
         """
         key_field_slugs = [field["slug"] for field in form.fields if field.get("isKeyField")]
+        key_fields_changed = self.cached_key_fields != key_field_slugs
 
         self.cached_key_fields = key_field_slugs
         self.save(update_fields=["cached_key_fields"])
@@ -322,6 +323,11 @@ class Survey(models.Model):
                     changed = True
             if changed:
                 other_form.save(update_fields=["fields", "cached_enriched_fields"])
+
+        if key_fields_changed:
+            from .response import Response
+
+            Response.refresh_cached_fields_qs(self.current_responses)
 
     def get_form(self, requested_language: str) -> Form | None:
         from .form import Form

--- a/kompassi/forms/models/survey.py
+++ b/kompassi/forms/models/survey.py
@@ -121,12 +121,16 @@ class Survey(models.Model):
         ),
     )
 
-    key_fields = ArrayField(
+    cached_key_fields = ArrayField(
         models.CharField(max_length=255),
         blank=True,
         default=list,
         verbose_name=_("key fields"),
-        help_text=_("Key fields will be shown in the response list."),
+        help_text=_(
+            "Key fields will be shown in the response list. "
+            "This field is denormalized from the isKeyField flag of the form fields "
+            "and should not be edited directly."
+        ),
     )
 
     subscribers = models.ManyToManyField(
@@ -295,6 +299,30 @@ class Survey(models.Model):
 
         return merge_fields(languages)
 
+    def refresh_cached_key_fields(self, form: Form) -> None:
+        """
+        cached_key_fields is denormalized from the isKeyField flag of the fields of the
+        language version (Form) being edited. Key field status is a survey-level concept,
+        so the flag is also synced to the other language versions.
+        """
+        key_field_slugs = [field["slug"] for field in form.fields if field.get("isKeyField")]
+
+        self.cached_key_fields = key_field_slugs
+        self.save(update_fields=["cached_key_fields"])
+
+        for other_form in self.languages.exclude(pk=form.pk):
+            changed = False
+            for field in other_form.fields:
+                desired = field["slug"] in key_field_slugs
+                if bool(field.get("isKeyField")) != desired:
+                    if desired:
+                        field["isKeyField"] = True
+                    else:
+                        field.pop("isKeyField", None)
+                    changed = True
+            if changed:
+                other_form.save(update_fields=["fields", "cached_enriched_fields"])
+
     def get_form(self, requested_language: str) -> Form | None:
         from .form import Form
 
@@ -398,7 +426,6 @@ class Survey(models.Model):
                 if self.purpose == SurveyPurpose.DEFAULT:
                     # The program offer workflow uses a dimension to lock responses from editing.
                     self.responses_editable_until = self.event.end_time
-                    self.key_fields = ["title"]
 
             case DimensionApp.FORMS:
                 if self.purpose == SurveyPurpose.INVITE:
@@ -434,7 +461,7 @@ class Survey(models.Model):
             anonymity=self.anonymity if anonymity is None else anonymity,
             login_required=self.login_required,
             max_responses_per_user=self.max_responses_per_user,
-            key_fields=self.key_fields,
+            cached_key_fields=self.cached_key_fields,
             protect_responses=self.protect_responses,
             created_by=created_by,
             registry=self.registry if registry is None else registry,
@@ -533,7 +560,7 @@ class SurveyDTO:
     login_required: bool = False
     max_responses_per_user: int = 0
     anonymity: str = "SOFT"
-    key_fields: list[str] = dataclasses.field(default_factory=list)
+    cached_key_fields: list[str] = dataclasses.field(default_factory=list)
     active_from: datetime | None = None
     active_until: datetime | None = None
 

--- a/kompassi/forms/models/survey.py
+++ b/kompassi/forms/models/survey.py
@@ -461,7 +461,6 @@ class Survey(models.Model):
             anonymity=self.anonymity if anonymity is None else anonymity,
             login_required=self.login_required,
             max_responses_per_user=self.max_responses_per_user,
-            cached_key_fields=self.cached_key_fields,
             protect_responses=self.protect_responses,
             created_by=created_by,
             registry=self.registry if registry is None else registry,
@@ -469,8 +468,11 @@ class Survey(models.Model):
 
         survey.save()
 
-        for form in self.languages.all():
-            form.clone(survey, created_by=created_by)
+        cloned_forms = [form.clone(survey, created_by=created_by) for form in self.languages.all()]
+
+        # cached_key_fields is denormalized from the isKeyField flag of the (cloned) form fields.
+        if cloned_forms:
+            survey.refresh_cached_key_fields(cloned_forms[0])
 
         return survey
 
@@ -560,7 +562,6 @@ class SurveyDTO:
     login_required: bool = False
     max_responses_per_user: int = 0
     anonymity: str = "SOFT"
-    cached_key_fields: list[str] = dataclasses.field(default_factory=list)
     active_from: datetime | None = None
     active_until: datetime | None = None
 
@@ -586,6 +587,7 @@ class SurveyDTO:
             dimensions = [DimensionDTO.model_validate(dimension) for dimension in data]
             DimensionDTO.save_many(survey.universe, dimensions)
 
+        last_form: Form | None = None
         for language in SUPPORTED_LANGUAGES:
             try:
                 with resource_stream(f"kompassi.events.{event.slug}", f"forms/{slug}-{language.code}.yml") as f:
@@ -600,5 +602,10 @@ class SurveyDTO:
                 defaults=data,
             )
             log_get_or_create(logger, form, created)
+            last_form = form
+
+        # cached_key_fields is denormalized from the isKeyField flag of the form fields.
+        if last_form is not None:
+            survey.refresh_cached_key_fields(last_form)
 
         return survey

--- a/kompassi/forms/tests.py
+++ b/kompassi/forms/tests.py
@@ -832,6 +832,45 @@ def test_survey_without_forms():
 
 
 @pytest.mark.django_db
+def test_refresh_cached_key_fields():
+    """
+    cached_key_fields is denormalized from the isKeyField flag of the form fields of the
+    language version being edited, and the flag is synced to the other language versions.
+    """
+    event, _created = Event.get_or_create_dummy()
+    survey = Survey.objects.create(event=event, slug="key-fields-survey")
+
+    en = Form.objects.create(
+        event=event,
+        survey=survey,
+        language="en",
+        fields=[
+            dict(slug="title", type="SingleLineText", isKeyField=True),
+            dict(slug="description", type="MultiLineText"),
+        ],
+    )
+    fi = Form.objects.create(
+        event=event,
+        survey=survey,
+        language="fi",
+        fields=[
+            dict(slug="title", type="SingleLineText"),
+            dict(slug="description", type="MultiLineText"),
+        ],
+    )
+
+    survey.refresh_cached_key_fields(en)
+
+    survey.refresh_from_db()
+    assert survey.cached_key_fields == ["title"]
+
+    # the isKeyField flag is synced to the other language version
+    fi.refresh_from_db()
+    assert next(field for field in fi.fields if field["slug"] == "title").get("isKeyField") is True
+    assert all(not field.get("isKeyField") for field in fi.fields if field["slug"] != "title")
+
+
+@pytest.mark.django_db
 def test_promote_field_to_dimension():
     with transaction.atomic():
         event, _created = Event.get_or_create_dummy()

--- a/kompassi/forms/tests.py
+++ b/kompassi/forms/tests.py
@@ -836,6 +836,7 @@ def test_refresh_cached_key_fields():
     """
     cached_key_fields is denormalized from the isKeyField flag of the form fields of the
     language version being edited, and the flag is synced to the other language versions.
+    Existing responses should also have their cached_key_fields refreshed.
     """
     event, _created = Event.get_or_create_dummy()
     survey = Survey.objects.create(event=event, slug="key-fields-survey")
@@ -859,6 +860,14 @@ def test_refresh_cached_key_fields():
         ],
     )
 
+    response = Response.objects.create(
+        form=en,
+        form_data={
+            "title": "Existing title",
+            "description": "Existing description",
+        },
+    )
+
     survey.refresh_cached_key_fields(en)
 
     survey.refresh_from_db()
@@ -868,6 +877,20 @@ def test_refresh_cached_key_fields():
     fi.refresh_from_db()
     assert next(field for field in fi.fields if field["slug"] == "title").get("isKeyField") is True
     assert all(not field.get("isKeyField") for field in fi.fields if field["slug"] != "title")
+
+    # Existing responses get refreshed when key field selection changes.
+    en.fields = [
+        dict(slug="title", type="SingleLineText"),
+        dict(slug="description", type="MultiLineText", isKeyField=True),
+    ]
+    en.save(update_fields=["fields", "cached_enriched_fields"])
+
+    survey.refresh_cached_key_fields(en)
+
+    survey.refresh_from_db()
+    response.refresh_from_db()
+    assert survey.cached_key_fields == ["description"]
+    assert response.cached_key_fields == {"description": "Existing description"}
 
 
 @pytest.mark.django_db

--- a/kompassi/program_v2/utils/default_fields.py
+++ b/kompassi/program_v2/utils/default_fields.py
@@ -15,6 +15,7 @@ def get_program_offer_form_default_fields(language: str) -> list[dict[str, Any]]
             slug="title",
             type=FieldType.SINGLE_LINE_TEXT,
             required=True,
+            is_key_field=True,
             title=get_message_in_language(TITLE, language),
         ),
         Field(


### PR DESCRIPTION
Key fields (shown in the response/program offer list) were stored as a
hardcoded list of slugs in Survey.key_fields. Rename that column to
Survey.cached_key_fields and denormalize it from a new per-field
isKeyField flag on Form.fields, editable via a checkbox in the form
field editor.

When form fields are saved, cached_key_fields is recomputed from the
language version being edited and the isKeyField flag is synced to the
other language versions. Program offer forms mark the title field as a
key field by default.

The GraphQL API field stays named keyFields; the cached/denormalized
nature is a backend implementation detail.

fixes #570

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
