### PR TITLE
fix(tickets_v2): include superseded product versions in orders filter

### DIFF
--- a/kompassi/tickets_v2/models/order.py
+++ b/kompassi/tickets_v2/models/order.py
@@ -238,7 +238,24 @@ class Order(OrderMixin, EventPartitionsMixin, UUID7Mixin, models.Model):
                         values = [PaymentStatus[value.upper()].value for value in values]
                         orders = orders.filter(cached_status__in=values)
                     case "product":
-                        orders = orders.filter(product_data__has_keys=values)
+                        product_ids = [int(value) for value in values]
+                        old_versions_by_current: dict[int, list[int]] = {}
+                        for old_id, current_id in Product.objects.filter(superseded_by_id__in=product_ids).values_list(
+                            "id", "superseded_by_id"
+                        ):
+                            old_versions_by_current.setdefault(current_id, []).append(old_id)
+
+                        query = models.Q()
+                        for product_id in product_ids:
+                            keys = [
+                                str(product_id),
+                                *(str(old_id) for old_id in old_versions_by_current.get(product_id, [])),
+                            ]
+                            sub_query = models.Q()
+                            for key in keys:
+                                sub_query |= models.Q(product_data__has_key=key)
+                            query &= sub_query
+                        orders = orders.filter(query)
 
         if search:
             # in case search is a formatted order number

--- a/kompassi/tickets_v2/tests.py
+++ b/kompassi/tickets_v2/tests.py
@@ -537,6 +537,47 @@ def test_vat_by_month_report_localized_titles(vat_report_event: Event):
 
 
 # ---------------------------------------------------------------------------
+# Order filtering tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_filter_orders_by_product_includes_superseded_versions(vat_report_event: Event):
+    """
+    Editing a product creates a new revision (superseded_by), but old orders keep
+    referencing the old product id in product_data. Filtering orders by the
+    current product id must still return orders made against an older, superseded
+    version of that product (see update_product.py:137-155 for how revisions are created).
+    """
+    old_product = Product.objects.create(
+        event=vat_report_event,
+        title="Seminar ticket",
+        description="",
+        price=Decimal("10.00"),
+        vat_percentage=Decimal("25.50"),
+    )
+    old_order_id = _make_order(vat_report_event, datetime(2026, 1, 1, 12, 0, tzinfo=UTC), {old_product.id: 1})
+
+    new_product = Product.objects.create(
+        event=vat_report_event,
+        title="Seminar ticket",
+        description="",
+        price=Decimal("12.00"),
+        vat_percentage=Decimal("25.50"),
+    )
+    old_product.superseded_by = new_product
+    old_product.save()
+    new_order_id = _make_order(vat_report_event, datetime(2026, 2, 1, 12, 0, tzinfo=UTC), {new_product.id: 1})
+
+    filters = [SimpleNamespace(dimension="product", values=[str(new_product.id)])]
+    filtered_order_ids = set(
+        Order.filter_orders(Order.objects.filter(event=vat_report_event), filters=filters).values_list("id", flat=True)
+    )
+
+    assert filtered_order_ids == {old_order_id, new_order_id}
+
+
+# ---------------------------------------------------------------------------
 # Customer self-service cancellation tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Editing a product creates a new revision and points old rows at it via
superseded_by, but existing orders keep referencing the old product id
in product_data. The Orders tab filtered strictly by the current
product id, so orders placed before the most recent edit were silently
excluded, while the Products tab's counts already rolled up the whole
version chain. filter_orders now expands each requested product id to
include its superseded versions before matching.

fixes #994

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
