### PR TITLE
fix(forms): stop persisting stale choices for dimension fields (fixes #919)

### DIFF
--- a/kompassi-v2-frontend/src/components/forms/FormEditor.tsx
+++ b/kompassi-v2-frontend/src/components/forms/FormEditor.tsx
@@ -58,6 +58,21 @@ function injectChoices(
   return field;
 }
 
+/// Inverse of injectChoices. Dimension fields' choices are only ever populated for display
+/// in the editor (see injectChoices above) or by server side enrichment (for the responder
+/// facing SchemaForm). They must never be persisted, or they will freeze stale values and
+/// translations in place until the field is next edited.
+function stripInjectedChoices(field: Field): Field {
+  if (
+    (field.type === "DimensionSingleSelect" ||
+      field.type === "DimensionMultiSelect") &&
+    field.dimension
+  ) {
+    return { ...field, choices: [] };
+  }
+  return field;
+}
+
 /** Fully controlled form editor component. */
 export default function FormEditor(props: Props) {
   const {
@@ -78,6 +93,11 @@ export default function FormEditor(props: Props) {
 
   const fields = value.map((field) => injectChoices(field, dimensions));
 
+  const handleChange = React.useCallback(
+    (newFields: Field[]) => onChange(newFields.map(stripInjectedChoices)),
+    [onChange],
+  );
+
   const handleAddField = React.useCallback(
     (fieldType: FieldType, aboveFieldSlug?: string) => {
       const usedIdentifiers = fields.map((field) => field.slug);
@@ -86,7 +106,7 @@ export default function FormEditor(props: Props) {
       if (["Divider", "Spacer"].includes(fieldType)) {
         // This field type has no options to be edited by the user,
         // so skip the edit dialog.
-        onChange(addField(fields, field, aboveFieldSlug));
+        handleChange(addField(fields, field, aboveFieldSlug));
       } else {
         setEditExisting(false);
         setTargetFieldName(aboveFieldSlug ?? "");
@@ -94,7 +114,7 @@ export default function FormEditor(props: Props) {
         setEditFieldModalOpen(true);
       }
     },
-    [fields, onChange],
+    [fields, handleChange],
   );
 
   const handleEditField = React.useCallback(
@@ -138,7 +158,7 @@ export default function FormEditor(props: Props) {
             <FormEditorControls
               value={fields}
               field={field}
-              onChange={onChange}
+              onChange={handleChange}
               onAddField={handleAddField}
               onRemoveField={handleRemoveField}
               onEditField={handleEditField}
@@ -158,7 +178,7 @@ export default function FormEditor(props: Props) {
         {...removeFieldModal}
         title={t.removeFieldModal.title}
         messages={t.removeFieldModal.actions}
-        onSubmit={() => onChange(removeField(fields, targetFieldName))}
+        onSubmit={() => handleChange(removeField(fields, targetFieldName))}
       >
         {t.removeFieldModal.message}
       </Modal>
@@ -172,7 +192,7 @@ export default function FormEditor(props: Props) {
               : addField(fields, values, targetFieldName);
 
             setEditFieldModalOpen(false);
-            onChange(newFields);
+            handleChange(newFields);
           }}
           onClose={() => setEditFieldModalOpen(false)}
           dimensions={dimensions}

--- a/kompassi/forms/graphql/mutations/update_form_fields.py
+++ b/kompassi/forms/graphql/mutations/update_form_fields.py
@@ -46,7 +46,17 @@ class UpdateFormFields(graphene.Mutation):
                 operation="update",
             )
 
-            form.fields = [field.model_dump(mode="json", by_alias=True) for field in fields.fields]
+            # Dimension fields' choices are only ever derived from the dimension at read time
+            # (see Form._enrich_field). Persisting client-supplied choices for them would freeze
+            # stale values and translations in place, so they must never be saved.
+            form.fields = [
+                field.model_dump(
+                    mode="json",
+                    by_alias=True,
+                    exclude={"choices"} if field.type.is_dimension_field else None,
+                )
+                for field in fields.fields
+            ]
             form.save(update_fields=["fields", "cached_enriched_fields"])
 
             survey.refresh_cached_key_fields(form)

--- a/kompassi/forms/management/commands/forms_strip_stale_dimension_choices.py
+++ b/kompassi/forms/management/commands/forms_strip_stale_dimension_choices.py
@@ -1,0 +1,37 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from ...models.field import FieldType
+from ...models.form import Form
+
+DIMENSION_FIELD_TYPES = {field_type.value for field_type in FieldType if field_type.is_dimension_field}
+
+
+class Command(BaseCommand):
+    help = (
+        "One-off fix for a bug where the survey editor persisted stale, "
+        "possibly mistranslated dimension choices into Form.fields. "
+        "Strips choices from dimension fields (they must only ever come "
+        "from live enrichment) and refreshes cached_enriched_fields."
+    )
+
+    def handle(self, *args, **options):
+        updated = 0
+
+        with transaction.atomic():
+            for form in Form.objects.select_for_update():
+                changed = False
+                new_fields = []
+
+                for field in form.fields:
+                    if field.get("type") in DIMENSION_FIELD_TYPES and field.get("choices"):
+                        field = {key: value for key, value in field.items() if key != "choices"}
+                        changed = True
+                    new_fields.append(field)
+
+                if changed:
+                    form.fields = new_fields
+                    form.save(update_fields=["fields", "cached_enriched_fields"])
+                    updated += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Stripped stale dimension choices from {updated} form(s)."))

--- a/kompassi/forms/tests.py
+++ b/kompassi/forms/tests.py
@@ -14,6 +14,7 @@ from kompassi.dimensions.models.enums import DimensionApp
 from kompassi.graphql_api.schema import schema
 
 from .excel_export import get_header_cells, get_response_cells
+from .graphql.mutations.update_form_fields import UpdateFormFields
 from .graphql.mutations.update_response_dimensions import UpdateResponseDimensions
 from .models.enums import SurveyPurpose
 from .models.field import Choice, Field, FieldType
@@ -891,6 +892,61 @@ def test_refresh_cached_key_fields():
     response.refresh_from_db()
     assert survey.cached_key_fields == ["description"]
     assert response.cached_key_fields == {"description": "Existing description"}
+
+
+@mock.patch("kompassi.forms.graphql.mutations.update_form_fields.graphql_check_instance", autospec=True)
+@pytest.mark.django_db
+def test_update_form_fields_strips_dimension_choices(_patched_graphql_check_instance):
+    """
+    Choices for dimension fields must only ever come from live enrichment (Form._enrich_field).
+    If the editor's client-supplied choices (see injectChoices in FormEditor.tsx) were persisted
+    as-is, they would go stale and out of date with the dimension whenever it or its values
+    are edited or translated.
+    """
+    event, _created = Event.get_or_create_dummy()
+    survey = Survey.objects.create(event=event, slug="test-survey")
+
+    dimension = Dimension.objects.create(universe=survey.universe, slug="test-dimension")
+    DimensionValue.objects.create(dimension=dimension, slug="test-value", title_en="Test value")
+
+    form = Form.objects.create(event=event, survey=survey, language="en", fields=[])
+
+    UpdateFormFields.mutate(
+        None,
+        MOCK_INFO,
+        SimpleNamespace(
+            event_slug=event.slug,
+            survey_slug=survey.slug,
+            language="en",
+            fields=[
+                dict(
+                    slug="test-dimension",
+                    type="DimensionSingleSelect",
+                    dimension="test-dimension",
+                    # simulates the stale choices the editor bakes in for display purposes
+                    choices=[dict(slug="test-value", title="Stale title")],
+                ),
+            ],
+        ),  # type: ignore
+    )
+
+    form.refresh_from_db()
+
+    field = next(f for f in form.fields if f["slug"] == "test-dimension")
+    assert "choices" not in field
+
+    enriched_field = next(f for f in form.cached_enriched_fields if f["slug"] == "test-dimension")
+    assert enriched_field["choices"] == [dict(slug="test-value", title="Test value")]
+
+    # Renaming the dimension value is reflected without the form ever being re-saved.
+    dimension_value = dimension.values.get()
+    dimension_value.title_en = "Renamed value"
+    dimension_value.save()
+    dimension.refresh_dependents()
+
+    form.refresh_from_db()
+    enriched_field = next(f for f in form.cached_enriched_fields if f["slug"] == "test-dimension")
+    assert enriched_field["choices"] == [dict(slug="test-value", title="Renamed value")]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Dimension fields' choices must only ever come from live enrichment
(Form._enrich_field), never from client input. The survey editor's
injectChoices was baking display-only choices into every field save,
freezing stale values and translations in the raw Form.fields JSON
that the editor reads back (enrich: false), while the responder view
stayed correct via cached_enriched_fields.

- Strip choices for dimension-typed fields in UpdateFormFields.mutate
  before persisting, with a regression test.
- Stop FormEditor.tsx's injectChoices output (used for display) from
  leaking into onChange/save paths.
- Add a one-off management command to backfill already-affected forms.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>