### PR TITLE
chore(linter): refactor hooks and linter config file excludes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@ repos:
       - id: ruff-check
         args:
           - --fix
-        exclude: ^kompassi/zombies/
       - id: ruff-format
         args:
           - --quiet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,17 +16,6 @@ repos:
       - id: end-of-file-fixer
         exclude: .*__generated__.*
       - id: trailing-whitespace
-  - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.6
-    hooks:
-      - id: prettier
-        exclude: |
-          (?x)(
-            .*__generated__.*|
-            ^kompassi/|
-            ^kubernetes/|
-            ^.github
-          )
   # XXX somehow the typechecking still leaks to parts of the code that is not yet ready for pyrekt
   # - repo: https://github.com/RobertCraigie/pyright-python
   #   rev: v1.1.367

--- a/kompassi-v2-frontend/.pre-commit-config.yaml
+++ b/kompassi-v2-frontend/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+minimum_pre_commit_version: 2.15.0
+
+repos:
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
+    hooks:
+      - id: prettier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ line-length = 120
 [tool.ruff]
 target-version = "py312"
 line-length = 120
+extend-exclude = ["kompassi/zombies/"]
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
This PR refactors `ruff` and `prettier` pre-commit hook configurations, so that excludes and ignores are read from the tools own configurations instead of from `.pre-commit-config.yaml`

- Moves `kompassi/zombies` exclude for `ruff` into `pyproject.toml`
- Moves `prettier` hook to frontend folder, so that `.prettierignore` is used
  - I was considering naming the new file `prek.toml`, but I felt like following the current convention was safer.
